### PR TITLE
use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/git-linearize
+++ b/git-linearize
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script makes sure that all commit hashes have nice and incremental prefixes.
 #
@@ -187,7 +187,7 @@ function cmd_install_hook() {
 	fi
 
 	cat >"$FILE" <<-EOM
-		#!/bin/bash
+		#!/usr/bin/env bash
 		git linearize ${FORWARD_IF_BRANCH} ${FORWARD_FORMAT}
 	EOM
 	chmod +x "$FILE"

--- a/hack/release
+++ b/hack/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function echoinfo() {
 	LIGHT_GREEN='\033[1;32m'

--- a/shit
+++ b/shit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # shit – Short Git.
 #


### PR DESCRIPTION
If bash is in your path but not in `/bin/bash` the scripts do not work. I've changed them so that `/usr/bin/env bash` is used everywhere instead.

I mimicked how you construct your commits (I think), but if you'd like them to be rewritten in some other way please also let me know.